### PR TITLE
Fix SvelteComponentWithConstructor type

### DIFF
--- a/src-ts/types.ts
+++ b/src-ts/types.ts
@@ -1,8 +1,7 @@
 import { SvelteComponent } from 'svelte';
 
-export type SvelteComponentWithConstructor = SvelteComponent & {
-	new(options: { target: HTMLElement, props: Record<string, any> }): SvelteComponent,
-};
+export type SvelteComponentWithConstructor =
+	new(options: { target: HTMLElement, props: Record<string, any> }) => SvelteComponent;
 
 export interface HistoryState {
 	timestamp: number,


### PR DESCRIPTION
Hi there! Really like the concept of your library!

This small PR fixes a type issue with `SvelteComponentWithConstructor`. In the current version you get type errors if you try to use it.